### PR TITLE
#79: train time에서 loss 출력 시 내용

### DIFF
--- a/train.py
+++ b/train.py
@@ -122,7 +122,7 @@ def train(params):
 
             images = images.to(device)
             labels = labels.to(device)
-            
+
             # Forward pass
             outputs = model(images)
 
@@ -141,21 +141,10 @@ def train(params):
 
             if (((current_train_step) % 100) == 0) or (current_train_step % 10 == 0 and current_train_step < 100):
                 print(
-                    'train steop [{}/{}], Epoch [{}/{}] ,Step [{}/{}] ,lr ,{} ,total_loss ,{:.4f} ,coord1 ,{} ,size1 ,{} ,noobj_clss ,{} ,objness1 ,{} ,'
-                    .format(current_train_step,
-                            total_train_step,
-                            epoch + 1,
-                            num_epochs,
-                            i + 1,
-                            total_step,
+                    'epoch: [{}/{}], total step: [{}/{}], batch step [{}/{}], lr: {}, total_loss: {:.4f}, coord1: {:.4f}, size1: {:.4f}, noobj_clss: {:.4f}, objness1: {:.4f}, class_loss: {:.4f}'
+                    .format(epoch + 1, num_epochs, current_train_step, total_train_step, i + 1, total_step,
                             [param_group['lr'] for param_group in optimizer.param_groups],
-                            loss.item(),
-                            obj_coord1_loss,
-                            obj_size1_loss,
-                            obj_class_loss,
-                            noobjness1_loss,
-                            objness1_loss
-                            ))
+                            loss.item(), obj_coord1_loss, obj_size1_loss, noobjness1_loss, objness1_loss, obj_class_loss))
 
                 if USE_VISDOM:
                     update_vis_plot(viz, (epoch + 1) * total_step + (i + 1), loss.item(), iter_plot, None, 'append')
@@ -166,7 +155,6 @@ def train(params):
                                     'append')
                     update_vis_plot(viz, (epoch + 1) * total_step + (i + 1), objness1_loss, objectness1_plot, None,
                                     'append')
-            
 
         if ((epoch % 1000) == 0) and (epoch != 0):
             save_checkpoint({
@@ -175,4 +163,3 @@ def train(params):
                 'state_dict': model.state_dict(),
                 'optimizer': optimizer.state_dict(),
             }, False, filename=os.path.join(checkpoint_path, 'checkpoint_{}.pth.tar'.format(epoch)))
-        

--- a/train.py
+++ b/train.py
@@ -143,7 +143,7 @@ def train(params):
                 print(
                     'epoch: [{}/{}], total step: [{}/{}], batch step [{}/{}], lr: {}, total_loss: {:.4f}, coord1: {:.4f}, size1: {:.4f}, noobj_clss: {:.4f}, objness1: {:.4f}, class_loss: {:.4f}'
                     .format(epoch + 1, num_epochs, current_train_step, total_train_step, i + 1, total_step,
-                            [param_group['lr'] for param_group in optimizer.param_groups],
+                            ([param_group['lr'] for param_group in optimizer.param_groups])[0],
                             loss.item(), obj_coord1_loss, obj_size1_loss, noobjness1_loss, objness1_loss, obj_class_loss))
 
                 if USE_VISDOM:


### PR DESCRIPTION
아래와 같이 출력됩니다.
```console
epoch: [1/16000], total step: [10/640000], batch step [10/40], lr: [0.001], total_loss: 2334.4236, coord1: 723.7835, size1: 1608.2457, noobj_clss: 0.0002, objness1: 1.2488, class_loss: 1.1454
epoch: [1/16000], total step: [20/640000], batch step [20/40], lr: [0.001], total_loss: 773.8732, coord1: 438.7300, size1: 332.1852, noobj_clss: 0.0000, objness1: 1.3077, class_loss: 1.6504
epoch: [1/16000], total step: [30/640000], batch step [30/40], lr: [0.001], total_loss: 578.5856, coord1: 243.9824, size1: 332.0176, noobj_clss: 0.0702, objness1: 1.2784, class_loss: 1.2371
epoch: [1/16000], total step: [40/640000], batch step [40/40], lr: [0.001], total_loss: 234.9386, coord1: 146.8672, size1: 85.9094, noobj_clss: 0.0314, objness1: 0.9899, class_loss: 1.1407
epoch: [2/16000], total step: [50/640000], batch step [10/40], lr: [0.001], total_loss: 93.6655, coord1: 39.0816, size1: 52.3115, noobj_clss: 0.1234, objness1: 1.0712, class_loss: 1.0777
epoch: [2/16000], total step: [60/640000], batch step [20/40], lr: [0.001], total_loss: 50.6393, coord1: 27.5499, size1: 19.6326, noobj_clss: 0.3414, objness1: 1.2685, class_loss: 1.8471
epoch: [2/16000], total step: [70/640000], batch step [30/40], lr: [0.001], total_loss: 16.7297, coord1: 5.9570, size1: 8.8120, noobj_clss: 0.0950, objness1: 0.8059, class_loss: 1.0598
epoch: [2/16000], total step: [80/640000], batch step [40/40], lr: [0.001], total_loss: 20.4047, coord1: 8.1417, size1: 9.8182, noobj_clss: 0.1283, objness1: 1.1037, class_loss: 1.2129
epoch: [3/16000], total step: [90/640000], batch step [10/40], lr: [0.001], total_loss: 19.4414, coord1: 7.3001, size1: 9.7556, noobj_clss: 0.1912, objness1: 1.1693, class_loss: 1.0252
epoch: [3/16000], total step: [100/640000], batch step [20/40], lr: [0.001], total_loss: 26.6456, coord1: 14.0809, size1: 10.6268, noobj_clss: 0.2571, objness1: 0.7337, class_loss: 0.9471
```


