### PR TITLE
[hotfix] Issue 96

### DIFF
--- a/test.py
+++ b/test.py
@@ -72,7 +72,6 @@ def test(params):
         outputs = outputs.view(w, h, c)
         outputs_np = outputs.cpu().data.numpy()
 
-
         outputs[:, :, 0] = torch.sigmoid(outputs[:, :, 0])
         outputs[:, :, 5:] = torch.sigmoid(outputs[:, :, 5:])
 
@@ -104,7 +103,6 @@ def test(params):
                         center_y = int((block[2] * H / 7.0) + (j * H / 7.0))
                         w_ratio = block[3]
                         h_ratio = block[4]
-
                         w_ratio = w_ratio * w_ratio
                         h_ratio = h_ratio * h_ratio
                         width = int(w_ratio * W)

--- a/train.py
+++ b/train.py
@@ -167,11 +167,10 @@ def train(params):
                                'obj_class_loss': obj_class_loss,
                                'noobjness1_loss': noobjness1_loss,
                                'objness1_loss': objness1_loss})
-
-          if ((epoch % 1000) == 0) and (epoch != 0):
-            save_checkpoint({
-                'epoch': epoch + 1,
-                'arch': "YOLOv1",
-                'state_dict': model.state_dict(),
-                'optimizer': optimizer.state_dict(),
-            }, False, filename=os.path.join(checkpoint_path, 'checkpoint_{}.pth.tar'.format(epoch)))
+            if ((epoch % 1000) == 0) and (epoch != 0):
+                save_checkpoint({
+                    'epoch': epoch + 1,
+                    'arch': "YOLOv1",
+                    'state_dict': model.state_dict(),
+                    'optimizer': optimizer.state_dict(),
+                }, False, filename=os.path.join(checkpoint_path, 'checkpoint_{}.pth.tar'.format(epoch)))

--- a/utilities/augmentation.py
+++ b/utilities/augmentation.py
@@ -3,7 +3,6 @@ from utilities.utils import CvtCoordsXXYY2XYWH
 from utilities.utils import CvtCoordsXYWH2XXYY
 from utilities.utils import GetImgaugStyleBBoxes
 from utilities.utils import GetYoloStyleBBoxes
-from utilities.utils import clippingBBox
 import imgaug as ia
 from imgaug import augmenters as iaa
 from PIL import Image


### PR DESCRIPTION
train 시도시
`train.py`의
`from utilities.augmentation import Augmenter`에서
`from utilities.utils import clippingBBox`에서 에러가 납니다.

최근 data augmentation작업시 box가 기존 이미지를 벗어나면 이를 수정하는 코드가
imgaug 유틸에서 지원하는 api를 사용해서 해결하는 방향으로 수정되어
clippingBBox가 삭제된 거 같은데 학습코드에 반영이 안되어있느 것으로 판단됩니다.

`from utilities.utils import clippingBBox`를 삭제하는 것으로 해결했습니다.