### PR TITLE
#82: CheckPoint 파일 이름 명세 변경

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 import argparse
-import git
+
 from train import train
 from test import test
 

--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ parser.add_argument('--use_augmentation', type=lambda x: (str(x).lower() == 'tru
 parser.add_argument('--use_visdom', type=lambda x: (str(x).lower() == 'true'), help='visdom board', default=True)
 parser.add_argument('--use_summary', type=lambda x: (str(x).lower() == 'true'), help='descripte Model summary', default=True)
 parser.add_argument('--use_gtcheck', type=lambda x: (str(x).lower() == 'true'), help='Ground Truth check flag', default=False)
+parser.add_argument('--use_githash', type=lambda x: (str(x).lower() == 'true'), help='use githash to checkpoint', default=False)
 
 # develop
 parser.add_argument('--num_class', type=int, help='number of class', default=5, required=True)

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import argparse
+import git
 from train import train
 from test import test
 

--- a/main.py
+++ b/main.py
@@ -49,8 +49,8 @@ def main():
         "use_augmentation": args.use_augmentation,
 
         "num_class": args.num_class,
-        "use_gtcheck": args.use_gtcheck
-
+        "use_gtcheck": args.use_gtcheck,
+        "use_githash": args.use_githash
     }
 
     if params["mode"] == "train":

--- a/train.py
+++ b/train.py
@@ -46,6 +46,7 @@ def train(params):
     USE_AUGMENTATION = params["use_augmentation"]
     USE_GTCHECKER = params["use_gtcheck"]
 
+    USE_GITHASH = params["use_githash"]
     num_class = params["num_class"]
 
     with open(class_path) as f:

--- a/train.py
+++ b/train.py
@@ -81,6 +81,11 @@ def train(params):
     else:
         seq = iaa.Sequential([])
 
+    if (USE_GITHASH):
+        repo = git.Repo(search_parent_directories=True)
+        sha = repo.head.object.hexsha
+        short_sha = repo.git.rev_parse(sha, short=7)
+
     composed = transforms.Compose([Augmenter(seq)])
 
     # 3. Load Dataset

--- a/train.py
+++ b/train.py
@@ -1,6 +1,7 @@
 import os
 import warnings
 
+import git
 import torch
 import torchvision.transforms as transforms
 import visdom

--- a/train.py
+++ b/train.py
@@ -122,7 +122,7 @@ def train(params):
 
             images = images.to(device)
             labels = labels.to(device)
-            
+
             # Forward pass
             outputs = model(images)
 
@@ -166,7 +166,6 @@ def train(params):
                                     'append')
                     update_vis_plot(viz, (epoch + 1) * total_step + (i + 1), objness1_loss, objectness1_plot, None,
                                     'append')
-            
 
         if ((epoch % 1000) == 0) and (epoch != 0):
             save_checkpoint({
@@ -174,5 +173,4 @@ def train(params):
                 'arch': "YOLOv1",
                 'state_dict': model.state_dict(),
                 'optimizer': optimizer.state_dict(),
-            }, False, filename=os.path.join(checkpoint_path, 'checkpoint_{}.pth.tar'.format(epoch)))
-        
+            }, False, filename=os.path.join(checkpoint_path, 'cp-{{epoch_{:05d}}} {{losses_{:.04f}}} {{lr_{}}}.pth.tar'.format(epoch, loss.item(), ([param_group['lr'] for param_group in optimizer.param_groups])[0])))

--- a/train.py
+++ b/train.py
@@ -54,6 +54,11 @@ def train(params):
 
     device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
 
+    if (USE_GITHASH):
+        repo = git.Repo(search_parent_directories=True)
+        sha = repo.head.object.hexsha
+        short_sha = repo.git.rev_parse(sha, short=7)
+
     if USE_VISDOM:
         viz = visdom.Visdom(use_incoming_socket=False)
         vis_title = 'Yolo V1 Deepbaksu_vision (feat. martin, visionNoob) PyTorch on ' + 'VOC'
@@ -80,11 +85,6 @@ def train(params):
         ])
     else:
         seq = iaa.Sequential([])
-
-    if (USE_GITHASH):
-        repo = git.Repo(search_parent_directories=True)
-        sha = repo.head.object.hexsha
-        short_sha = repo.git.rev_parse(sha, short=7)
 
     composed = transforms.Compose([Augmenter(seq)])
 

--- a/train.py
+++ b/train.py
@@ -167,13 +167,9 @@ def train(params):
                     update_vis_plot(viz, (epoch + 1) * total_step + (i + 1), noobjness1_loss, noobjectness1_plot, None, 'append')
                     update_vis_plot(viz, (epoch + 1) * total_step + (i + 1), objness1_loss, objectness1_plot, None, 'append')
 
-                 if USE_WANDB:
-                    wandb.log({'total_loss': loss.item(),
-                               'obj_coord1_loss': obj_coord1_loss,
-                               'obj_size1_loss': obj_size1_loss,
-                               'obj_class_loss': obj_class_loss,
-                               'noobjness1_loss': noobjness1_loss,
-                               'objness1_loss': objness1_loss})
+                if USE_WANDB:
+                    wandb.log({'total_loss': loss.item(), 'obj_coord1_loss': obj_coord1_loss, 'obj_size1_loss': obj_size1_loss,
+                            'obj_class_loss': obj_class_loss, 'noobjness1_loss': noobjness1_loss, 'objness1_loss': objness1_loss})
 
         if not USE_GITHASH:
             short_sha = 'noHash'
@@ -185,4 +181,3 @@ def train(params):
                 'state_dict': model.state_dict(),
                 'optimizer': optimizer.state_dict(),
             }, False, filename=os.path.join(checkpoint_path, 'ckpt_{}_ep{:05d}_loss{:.04f}_lr{}.pth.tar'.format(short_sha, epoch, loss.item(), ([param_group['lr'] for param_group in optimizer.param_groups])[0])))
-

--- a/train.py
+++ b/train.py
@@ -175,7 +175,7 @@ def train(params):
                                     'append')
 
         if not USE_GITHASH:
-            short_sha = 'no_hash'
+            short_sha = 'noHash'
 
         if ((epoch % 1) == 0) and (epoch != 0):
             save_checkpoint({
@@ -183,4 +183,4 @@ def train(params):
                 'arch': "YOLOv1",
                 'state_dict': model.state_dict(),
                 'optimizer': optimizer.state_dict(),
-            }, False, filename=os.path.join(checkpoint_path, 'cp({})-epoch_{:05d},losses_{:.04f},lr_{}.pth.tar'.format(short_sha, epoch, loss.item(), ([param_group['lr'] for param_group in optimizer.param_groups])[0])))
+            }, False, filename=os.path.join(checkpoint_path, 'ckpt_{}_ep{:05d}_loss{:.04f}_lr{}.pth.tar'.format(short_sha, epoch, loss.item(), ([param_group['lr'] for param_group in optimizer.param_groups])[0])))

--- a/train.py
+++ b/train.py
@@ -174,10 +174,13 @@ def train(params):
                     update_vis_plot(viz, (epoch + 1) * total_step + (i + 1), objness1_loss, objectness1_plot, None,
                                     'append')
 
-        if ((epoch % 1000) == 0) and (epoch != 0):
+        if not USE_GITHASH:
+            short_sha = 'no_hash'
+
+        if ((epoch % 1) == 0) and (epoch != 0):
             save_checkpoint({
                 'epoch': epoch + 1,
                 'arch': "YOLOv1",
                 'state_dict': model.state_dict(),
                 'optimizer': optimizer.state_dict(),
-            }, False, filename=os.path.join(checkpoint_path, 'cp-{{epoch_{:05d}}} {{losses_{:.04f}}} {{lr_{}}}.pth.tar'.format(epoch, loss.item(), ([param_group['lr'] for param_group in optimizer.param_groups])[0])))
+            }, False, filename=os.path.join(checkpoint_path, 'cp({})-epoch_{:05d},losses_{:.04f},lr_{}.pth.tar'.format(short_sha, epoch, loss.item(), ([param_group['lr'] for param_group in optimizer.param_groups])[0])))


### PR DESCRIPTION
checkpoint가 다음과 같이 변경됩니다. 
```
ckpt_db6e558_ep00001_loss16.4490_lr0.001.pth.tar
```

loss를 lo로 생략하지 않은 이유는 lo끝에 o 로 인해 가독성이 떨어진다고 판단했습니다. 
e.g. ckpt_db6e558_ep00001_lo16.4490_lr0.001.pth.tar :(  