### PR TITLE
 #99 : modified return value as augmentated label value

### DIFF
--- a/utilities/dataloader.py
+++ b/utilities/dataloader.py
@@ -182,4 +182,4 @@ class VOC(data.Dataset):
             # Future works
             pass
 
-        return img, target, current_shape
+        return img, aug_target, current_shape


### PR DESCRIPTION
 Augmentation시 rotate | Scale 변환시 label 변환이 의도한 바로 작동하지 않음

Augmentation 작업시 rotation 및 scale 변환이 들어가게 되면 label이 변환되지 않은건지, 잘못된건지
이상한 값이 나옵니다.

=> __getitem__ 함수의 label return값이 변환되지 않은 target값으로 반환되고있는 것을 확인했습니다. 수정 후, 결과를 확인했습니다.

결과는 #99 확인 부탁드립니다.